### PR TITLE
feat(无限画布): 添加可选的无限画布功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dist/*
 # generated translation files
 /translations
 /locale
+
+# local history
+.history

--- a/src/containers/paper-canvas.jsx
+++ b/src/containers/paper-canvas.jsx
@@ -9,7 +9,7 @@ import {ensureClockwise, scaleWithStrokes} from '../helper/math';
 import {performSnapshot} from '../helper/undo';
 import {
     BASE,
-    clampViewBounds, resetZoom, resizeCrosshair, setWorkspaceBounds, zoomToFit
+    clampViewBounds, resetZoom, resizeCrosshair, setWorkspaceBounds, zoomToFit, isInfiniteCanvasEnabled
 } from '../helper/view';
 import Formats from '../lib/format';
 import log from '../log/log';
@@ -21,6 +21,7 @@ import {clearUndoState, undoSnapshot} from '../reducers/undo';
 import {updateViewBounds} from '../reducers/view-bounds';
 import {saveZoomLevel, setZoomLevelId} from '../reducers/zoom-levels';
 import styles from './paper-canvas.css';
+import {setupInfiniteBackgroundUpdates, forceUpdateInfiniteBackground, watchInfiniteCanvasModeToggle, stopWatchingInfiniteCanvasModeToggle} from '../helper/dynamic-background';
 
 
 class PaperCanvas extends React.Component {
@@ -65,6 +66,12 @@ class PaperCanvas extends React.Component {
         updateTheme(this.props.theme);
         this.importImage(
             this.props.imageFormat, this.props.image, this.props.rotationCenterX, this.props.rotationCenterY);
+        if (isInfiniteCanvasEnabled()) {
+            setupInfiniteBackgroundUpdates();
+            forceUpdateInfiniteBackground();
+        }
+        // Start watching for infinite mode toggle and rebuild background when changed
+        watchInfiniteCanvasModeToggle(() => this.props.format);
     }
     componentWillReceiveProps (newProps) {
         if (this.props.imageId !== newProps.imageId) {
@@ -86,6 +93,8 @@ class PaperCanvas extends React.Component {
         if (!this.shouldZoomToFit) {
             this.props.saveZoomLevel();
         }
+        // Stop mode watcher to avoid leaks
+        stopWatchingInfiniteCanvasModeToggle();
         paper.remove();
     }
     clearQueuedImport () {
@@ -141,11 +150,14 @@ class PaperCanvas extends React.Component {
             // import bitmap
             this.props.changeFormat(Formats.BITMAP_SKIP_CONVERT);
 
-            const mask = new paper.Shape.Rectangle(getRaster().getBounds());
-            mask.guide = true;
-            mask.locked = true;
-            mask.setPosition(BASE.CENTER);
-            mask.clipMask = true;
+            // Only create mask in non-infinite canvas mode
+            if (!isInfiniteCanvasEnabled()) {
+                const mask = new paper.Shape.Rectangle(getRaster().getBounds());
+                mask.guide = true;
+                mask.locked = true;
+                mask.setPosition(BASE.CENTER);
+                mask.clipMask = true;
+            }
 
             const imgElement = new Image();
             this.queuedImageToLoad = imgElement;
@@ -265,12 +277,19 @@ class PaperCanvas extends React.Component {
         mask.guide = true;
         mask.locked = true;
         mask.matrix = new paper.Matrix(); // Identity
-        // Set the artwork to get clipped at the max costume size
-        mask.size.height = BASE.MAX_WORKSPACE_BOUNDS.height;
-        mask.size.width = BASE.MAX_WORKSPACE_BOUNDS.width;
-        mask.setPosition(BASE.CENTER);
-        paper.project.activeLayer.addChild(mask);
-        mask.clipMask = true;
+        
+        // In infinite canvas mode, don't apply clipping mask
+        if (!isInfiniteCanvasEnabled()) {
+            // Set the artwork to get clipped at the max costume size
+            mask.size.height = BASE.MAX_WORKSPACE_BOUNDS.height;
+            mask.size.width = BASE.MAX_WORKSPACE_BOUNDS.width;
+            mask.setPosition(BASE.CENTER);
+            paper.project.activeLayer.addChild(mask);
+            mask.clipMask = true;
+        } else {
+            // In infinite canvas mode, remove the mask to avoid clipping
+            mask.remove();
+        }
 
         // Reduce single item nested in groups
         if (item instanceof paper.Group && item.children.length === 1) {

--- a/src/containers/scrollable-canvas.jsx
+++ b/src/containers/scrollable-canvas.jsx
@@ -8,6 +8,7 @@ import ScrollableCanvasComponent from '../components/scrollable-canvas/scrollabl
 import {clampViewBounds, pan, zoomOnFixedPoint, getWorkspaceBounds} from '../helper/view';
 import {updateViewBounds} from '../reducers/view-bounds';
 import {redrawSelectionBox} from '../reducers/selected-items';
+import {updateInfiniteBackgroundThrottled} from '../helper/dynamic-background';
 
 import {getEventXY} from '../lib/touch-utils';
 import bindAll from 'lodash.bindall';
@@ -68,6 +69,7 @@ class ScrollableCanvas extends React.Component {
         paper.view.matrix.tx = this.initialScreenX - (this.initialMouseX - x);
         clampViewBounds();
         this.props.updateViewBounds(paper.view.matrix);
+        updateInfiniteBackgroundThrottled(); // Update background on pan
         if (this.props.canvas) {
             this.props.canvas.style.cursor = 'move';
         }
@@ -147,6 +149,7 @@ class ScrollableCanvas extends React.Component {
             zoomOnFixedPoint(-deltaY / 500, fixedPoint);
             this.props.updateViewBounds(paper.view.matrix);
             this.props.redrawSelectionBox(); // Selection handles need to be resized after zoom
+            updateInfiniteBackgroundThrottled();
         } else if (event.shiftKey && event.deltaX === 0) {
             // Scroll horizontally (based on vertical scroll delta)
             // This is needed as for some browser/system combinations which do not set deltaX.
@@ -154,11 +157,13 @@ class ScrollableCanvas extends React.Component {
             const dx = deltaY / paper.view.zoom;
             pan(dx, 0);
             this.props.updateViewBounds(paper.view.matrix);
+            updateInfiniteBackgroundThrottled();
         } else {
             const dx = deltaX / paper.view.zoom;
             const dy = deltaY / paper.view.zoom;
             pan(dx, dy);
             this.props.updateViewBounds(paper.view.matrix);
+            updateInfiniteBackgroundThrottled();
             if (paper.tool) {
                 paper.tool.view._handleMouseEvent('mousemove', event, fixedPoint);
             }

--- a/src/helper/bit-tools/line-tool.js
+++ b/src/helper/bit-tools/line-tool.js
@@ -1,7 +1,7 @@
 import paper from '@scratch/paper';
 import {forEachLinePoint, getBrushMark} from '../bitmap';
 import {createCanvas, getGuideLayer, getRaster} from '../layer';
-import {BASE} from '../view';
+import {BASE, isInfiniteCanvasEnabled} from '../view';
 
 /**
  * Tool for drawing lines with the bitmap brush.
@@ -91,7 +91,12 @@ class LineTool extends paper.Tool {
 
         // Clear
         const context = this.drawTarget.canvas.getContext('2d');
-        context.clearRect(0, 0, BASE.ART_BOARD_WIDTH, BASE.ART_BOARD_HEIGHT);
+        if (isInfiniteCanvasEnabled()) {
+            // In infinite canvas mode, clear the entire canvas
+            context.clearRect(0, 0, this.drawTarget.canvas.width, this.drawTarget.canvas.height);
+        } else {
+            context.clearRect(0, 0, BASE.ART_BOARD_WIDTH, BASE.ART_BOARD_HEIGHT);
+        }
 
         forEachLinePoint(this.startPoint, event.point, this.draw.bind(this));
     }

--- a/src/helper/dynamic-background.js
+++ b/src/helper/dynamic-background.js
@@ -1,0 +1,266 @@
+import paper from '@scratch/paper';
+import { isInfiniteCanvasEnabled, BASE } from './view';
+import { getBackgroundGuideLayer, rebuildBackgroundGuideLayer } from './layer';
+
+const CHECKERBOARD_SIZE = 8;
+let lastViewCenter = null;
+let lastViewZoom = null;
+let updateBackgroundTimeout = null;
+// 新增：节流状态标记
+let throttleCooling = false;
+let throttlePending = false;
+
+// Track mode changes
+let lastInfiniteMode = null;
+let modeWatchInterval = null;
+let _getCurrentFormat = null;
+// Keep original onFrame so we can restore it when leaving infinite mode
+let originalOnFrameHandler = null;
+let onFrameWrapped = false;
+
+/**
+ * Update the infinite canvas background to cover the current view
+ */
+const updateInfiniteBackground = () => {
+    if (!isInfiniteCanvasEnabled() || !paper.view) return;
+    const backgroundGuideLayer = getBackgroundGuideLayer();
+    if (!backgroundGuideLayer || !backgroundGuideLayer.vectorBackground) return;
+
+    const vectorBackground = backgroundGuideLayer.vectorBackground;
+
+    // Find the background group (should be the last child in infinite canvas mode)
+    let backgroundGroup = null;
+    for (let i = vectorBackground.children.length - 1; i >= 0; i--) {
+        const child = vectorBackground.children[i];
+        if (child.children && child.children.length >= 2) {
+            backgroundGroup = child;
+            break;
+        }
+    }
+
+    if (!backgroundGroup) return;
+
+    // Calculate new background size based on current view
+    const viewBounds = paper.view.bounds;
+    const scale = Math.max(3, Math.ceil(Math.max(viewBounds.width, viewBounds.height) / BASE.ART_BOARD_WIDTH));
+    const newSize = {
+        width: BASE.ART_BOARD_WIDTH * scale,
+        height: BASE.ART_BOARD_HEIGHT * scale
+    };
+
+    // Update background position aligned to grid based on current view
+    const c = paper.view.center;
+    const tileSize = ((backgroundGroup.scaling && backgroundGroup.scaling.x) ? backgroundGroup.scaling.x : CHECKERBOARD_SIZE) * 16; // for a tile size, 8px
+    const mod = (a, b) => ((a % b) + b) % b; // floor-style positive modulo
+    const alignedX = c.x - mod(c.x, tileSize);
+    const alignedY = c.y - mod(c.y, tileSize);
+    backgroundGroup.position = new paper.Point(alignedX, alignedY);
+
+    // Update background size by scaling
+    const currentSize = backgroundGroup.bounds;
+    if (currentSize.width > 0 && currentSize.height > 0) {
+        const scaleX = newSize.width / currentSize.width;
+        const scaleY = newSize.height / currentSize.height;
+        const uniformScale = Math.max(scaleX, scaleY);
+
+        // Only scale if the change is significant (avoid unnecessary updates)
+        if (uniformScale < 0.7 || uniformScale > 1.5) {
+            backgroundGroup.scale(uniformScale, backgroundGroup.position);
+        }
+    }
+};
+
+/**
+ * Throttled version of updateInfiniteBackground to avoid excessive updates
+ */
+const updateInfiniteBackgroundThrottled = () => {
+    if (!throttleCooling) {
+        throttleCooling = true;
+        updateInfiniteBackground();
+        if (updateBackgroundTimeout) clearTimeout(updateBackgroundTimeout);
+        updateBackgroundTimeout = setTimeout(() => {
+            throttleCooling = false;
+            if (throttlePending) {
+                throttlePending = false;
+                updateInfiniteBackgroundThrottled();
+            }
+        }, 100); // Max 10 updates per second
+    } else {
+        throttlePending = true;
+    }
+};
+
+/**
+ * Apply/Remove workspace clipping mask based on current mode.
+ * This affects already imported SVG/Bitmap content when toggling modes.
+ */
+const adjustWorkspaceMaskForMode = () => {
+    if (!paper.project || !paper.project.activeLayer) return;
+    const layer = paper.project.activeLayer;
+
+    // Find existing clip mask (if any)
+    let mask = null;
+    if (layer.children) {
+        for (const child of layer.children) {
+            if (typeof child.isClipMask === 'function' && child.isClipMask()) {
+                mask = child;
+                break;
+            }
+        }
+    }
+
+    if (isInfiniteCanvasEnabled()) {
+        // Remove clipping in infinite mode
+        if (mask) {
+            layer.clipped = false;
+            mask.remove();
+        }
+    } else {
+        // Ensure clipping exists and matches workspace bounds in bounded mode
+        if (!mask) {
+            mask = new paper.Shape.Rectangle(BASE.MAX_WORKSPACE_BOUNDS);
+            mask.guide = true;
+            mask.locked = true;
+            mask.position = BASE.CENTER;
+            layer.addChild(mask);
+            mask.clipMask = true;
+        } else {
+            mask.size.height = BASE.MAX_WORKSPACE_BOUNDS.height;
+            mask.size.width = BASE.MAX_WORKSPACE_BOUNDS.width;
+            mask.setPosition(BASE.CENTER);
+            mask.clipMask = true;
+        }
+    }
+};
+
+/**
+ * Set up event listeners for view changes in infinite canvas mode
+ */
+const setupInfiniteBackgroundUpdates = () => {
+    if (!isInfiniteCanvasEnabled()) return;
+
+    // Ensure paper.view is available with retry mechanism
+    const setupWithRetry = (retryCount = 0) => {
+        if (paper.view) {
+            // // Avoid wrapping multiple times
+            // if (!onFrameWrapped) {
+            //     originalOnFrameHandler = paper.view.onFrame;
+            //     const wrappedOnFrame = (event) => {
+            //         if (originalOnFrameHandler) originalOnFrameHandler.call(paper.view, event);
+            //         updateInfiniteBackgroundThrottled();
+            //     };
+            //     paper.view.onFrame = wrappedOnFrame;
+            //     onFrameWrapped = true;
+            // }
+
+            // Force initial background update after setup
+            setTimeout(() => {
+                forceUpdateInfiniteBackground();
+            }, 50);
+        } else if (retryCount < 10) {
+            // Retry up to 10 times with exponential backoff
+            setTimeout(() => {
+                setupWithRetry(retryCount + 1);
+            }, Math.min(100 * Math.pow(2, retryCount), 1000));
+        }
+    };
+
+    setupWithRetry();
+};
+
+// Tear down listeners and timers when leaving infinite mode
+const teardownInfiniteBackgroundUpdates = () => {
+    if (updateBackgroundTimeout) {
+        clearTimeout(updateBackgroundTimeout);
+        updateBackgroundTimeout = null;
+    }
+    if (paper.view && onFrameWrapped) {
+        paper.view.onFrame = originalOnFrameHandler;
+        originalOnFrameHandler = null;
+        onFrameWrapped = false;
+    }
+    lastViewCenter = null;
+    lastViewZoom = null;
+    throttleCooling = false;
+    throttlePending = false;
+};
+
+/**
+ * Watch for changes in infinite canvas mode and rebuild background accordingly
+ * @param {Function} getCurrentFormat - A function returning current image format string
+ */
+const watchInfiniteCanvasModeToggle = (getCurrentFormat) => {
+    _getCurrentFormat = getCurrentFormat;
+    lastInfiniteMode = isInfiniteCanvasEnabled();
+
+    if (modeWatchInterval) {
+        clearInterval(modeWatchInterval);
+    }
+
+    modeWatchInterval = setInterval(() => {
+        const currentMode = isInfiniteCanvasEnabled();
+        if (currentMode !== lastInfiniteMode) {
+            lastInfiniteMode = currentMode;
+            const format = typeof _getCurrentFormat === 'function' ? _getCurrentFormat() : undefined;
+            // Rebuild background to reflect new mode
+            rebuildBackgroundGuideLayer(format);
+            // Sync clipping with new mode for already imported content
+            adjustWorkspaceMaskForMode();
+
+            if (currentMode) {
+                // When switching to infinite mode, set up updates and force refresh
+                setupInfiniteBackgroundUpdates();
+                forceUpdateInfiniteBackground();
+            } else {
+                // When switching back, restore original onFrame and clear timers
+                teardownInfiniteBackgroundUpdates();
+            }
+        }
+    }, 250);
+};
+
+/**
+ * Stop watching for infinite canvas mode changes
+ */
+const stopWatchingInfiniteCanvasModeToggle = () => {
+    if (modeWatchInterval) {
+        clearInterval(modeWatchInterval);
+        modeWatchInterval = null;
+    }
+    _getCurrentFormat = null;
+    // Also tear down in case we're leaving while wrapped
+    teardownInfiniteBackgroundUpdates();
+};
+
+/**
+ * Force an immediate background update
+ */
+const forceUpdateInfiniteBackground = () => {
+    if (updateBackgroundTimeout) {
+        clearTimeout(updateBackgroundTimeout);
+        updateBackgroundTimeout = null;
+    }
+    // if we're not ready yet, try again later
+    const tryUpdate = (retryCount = 0) => {
+        if (paper.view) {
+            lastViewCenter = null; // Force update on next check
+            lastViewZoom = null;
+            updateInfiniteBackground();
+        } else if (retryCount < 10) {
+            setTimeout(() => tryUpdate(retryCount + 1), Math.min(100 * Math.pow(2, retryCount), 1000));
+        }
+    };
+
+    tryUpdate();
+};
+
+export {
+    updateInfiniteBackground,
+    updateInfiniteBackgroundThrottled,
+    setupInfiniteBackgroundUpdates,
+    // expose teardown for completeness (optional external use)
+    teardownInfiniteBackgroundUpdates,
+    forceUpdateInfiniteBackground,
+    watchInfiniteCanvasModeToggle,
+    stopWatchingInfiniteCanvasModeToggle
+};

--- a/src/helper/layer.js
+++ b/src/helper/layer.js
@@ -1,8 +1,8 @@
 import paper from '@scratch/paper';
-import {isBitmap, isVector} from '../lib/format';
+import { isBitmap, isVector } from '../lib/format';
 import log from '../log/log';
-import {isGroupItem} from './item';
-import {BASE} from './view';
+import { isGroupItem } from './item';
+import { BASE, isInfiniteCanvasEnabled } from './view';
 
 const CHECKERBOARD_SIZE = 8;
 const CROSSHAIR_SIZE = 16;
@@ -28,8 +28,26 @@ const _getPaintingLayer = function () {
  */
 const createCanvas = function (width, height) {
     const canvas = document.createElement('canvas');
-    canvas.width = width ? width : BASE.ART_BOARD_WIDTH;
-    canvas.height = height ? height : BASE.ART_BOARD_HEIGHT;
+    if (width && height) {
+        canvas.width = width;
+        canvas.height = height;
+    } else if (isInfiniteCanvasEnabled()) {
+        // In infinite canvas mode, create a larger default canvas
+        const viewBounds = paper.view ? paper.view.bounds : null;
+        if (viewBounds) {
+            // Create canvas based on current view bounds with some padding
+            const padding = Math.max(BASE.ART_BOARD_WIDTH, BASE.ART_BOARD_HEIGHT);
+            canvas.width = Math.max(BASE.ART_BOARD_WIDTH, viewBounds.width + padding * 2);
+            canvas.height = Math.max(BASE.ART_BOARD_HEIGHT, viewBounds.height + padding * 2);
+        } else {
+            // Fallback to larger default size
+            canvas.width = BASE.ART_BOARD_WIDTH * 4;
+            canvas.height = BASE.ART_BOARD_HEIGHT * 4;
+        }
+    } else {
+        canvas.width = BASE.ART_BOARD_WIDTH;
+        canvas.height = BASE.ART_BOARD_HEIGHT;
+    }
     canvas.getContext('2d').imageSmoothingEnabled = false;
     return canvas;
 };
@@ -204,25 +222,33 @@ const _makeBackgroundPaper = function (width, height, opacity) {
         pathPoints.push(new paper.Point(x, y));
         y--;
     }
-    const vRect = new paper.Shape.Rectangle(
-        new paper.Point(0, 0),
-        new paper.Point(BASE.ART_BOARD_WIDTH / CHECKERBOARD_SIZE, BASE.ART_BOARD_HEIGHT / CHECKERBOARD_SIZE));
+
+    const vRect = isInfiniteCanvasEnabled() ?
+        new paper.Shape.Rectangle(
+            new paper.Point(0, 0),
+            new paper.Point(width, height)) :
+        new paper.Shape.Rectangle(
+            new paper.Point(0, 0),
+            new paper.Point(BASE.ART_BOARD_WIDTH / CHECKERBOARD_SIZE, BASE.ART_BOARD_HEIGHT / CHECKERBOARD_SIZE));
     vRect.fillColor = BACKGROUND_LIGHT;
     vRect.guide = true;
     vRect.locked = true;
-    vRect.position = BASE.CENTER;
     const vPath = new paper.Path(pathPoints);
     vPath.fillRule = 'evenodd';
     vPath.fillColor = BACKGROUND_TILE_LIGHT;
     vPath.opacity = opacity;
     vPath.guide = true;
     vPath.locked = true;
-    vPath.position = BASE.CENTER;
-    const mask = new paper.Shape.Rectangle(BASE.MAX_WORKSPACE_BOUNDS);
-    mask.position = BASE.CENTER;
+    let mask = new paper.Shape.Rectangle(new paper.Point(0, 0), new paper.Point(width, height));
+    if (!isInfiniteCanvasEnabled()) {
+        vRect.position = BASE.CENTER;
+        vPath.position = BASE.CENTER;
+        mask = new paper.Shape.Rectangle(BASE.MAX_WORKSPACE_BOUNDS);
+        mask.position = BASE.CENTER;
+        mask.scale(1 / CHECKERBOARD_SIZE);
+    }
     mask.guide = true;
     mask.locked = true;
-    mask.scale(1 / CHECKERBOARD_SIZE);
     const vGroup = new paper.Group([vRect, vPath, mask]);
     mask.clipMask = true;
     return vGroup;
@@ -308,21 +334,58 @@ const _makeBackgroundGuideLayer = function (format) {
     const guideLayer = new paper.Layer();
     guideLayer.locked = true;
 
-    const vWorkspaceBounds = new paper.Shape.Rectangle(BASE.MAX_WORKSPACE_BOUNDS);
-    vWorkspaceBounds.fillColor = WORKSPACE_BOUNDS_LIGHT;
-    vWorkspaceBounds.position = BASE.CENTER;
+    const vectorBackground = new paper.Group();
 
-    // Add 1 to the height because it's an odd number otherwise, and we want it to be even
-    // so the corner of the checkerboard to line up with the center crosshair
+    // Only create workspace bounds in non-infinite canvas mode
+    if (!isInfiniteCanvasEnabled()) {
+        const vWorkspaceBounds = new paper.Shape.Rectangle(BASE.MAX_WORKSPACE_BOUNDS);
+        vWorkspaceBounds.fillColor = WORKSPACE_BOUNDS_LIGHT;
+        vWorkspaceBounds.position = BASE.CENTER;
+        vectorBackground.addChild(vWorkspaceBounds);
+    }
+
+    // Create dynamic background based on infinite canvas mode
+    let backgroundSize;
+    if (isInfiniteCanvasEnabled()) {
+        // For infinite canvas, create a much larger background that adapts to view
+        const viewBounds = paper.view ? paper.view.bounds : null;
+        if (viewBounds) {
+            const scale = Math.max(4, Math.ceil(Math.max(viewBounds.width, viewBounds.height) / BASE.ART_BOARD_WIDTH));
+            backgroundSize = {
+                width: BASE.ART_BOARD_WIDTH * scale / CHECKERBOARD_SIZE,
+                height: BASE.ART_BOARD_HEIGHT * scale / CHECKERBOARD_SIZE
+            };
+        } else {
+            console.log("No view bounds found");
+            backgroundSize = {
+                width: BASE.ART_BOARD_WIDTH * 8 / CHECKERBOARD_SIZE,
+                height: BASE.ART_BOARD_HEIGHT * 8 / CHECKERBOARD_SIZE
+            };
+        }
+    } else {
+        console.log("No workspace bounds found");
+        // Add 1 to the height because it's an odd number otherwise, and we want it to be even
+        // so the corner of the checkerboard to line up with the center crosshair
+        backgroundSize = {
+            width: BASE.MAX_WORKSPACE_BOUNDS.width / CHECKERBOARD_SIZE,
+            height: (BASE.MAX_WORKSPACE_BOUNDS.height / CHECKERBOARD_SIZE) + 1
+        };
+    }
+
     const vBackground = _makeBackgroundPaper(
-        BASE.MAX_WORKSPACE_BOUNDS.width / CHECKERBOARD_SIZE,
-        (BASE.MAX_WORKSPACE_BOUNDS.height / CHECKERBOARD_SIZE) + 1,
+        backgroundSize.width,
+        backgroundSize.height,
         0.55);
-    vBackground.position = BASE.CENTER;
+
+    if (isInfiniteCanvasEnabled()) {
+        const viewCenter = paper.view ? paper.view.center : BASE.CENTER;
+        vBackground.position = viewCenter;
+    } else {
+        vBackground.position = BASE.CENTER;
+    }
+
     vBackground.scaling = new paper.Point(CHECKERBOARD_SIZE, CHECKERBOARD_SIZE);
 
-    const vectorBackground = new paper.Group();
-    vectorBackground.addChild(vWorkspaceBounds);
     vectorBackground.addChild(vBackground);
     setGuideItem(vectorBackground);
     guideLayer.vectorBackground = vectorBackground;
@@ -354,9 +417,16 @@ const updateTheme = function (theme) {
     bitmapChildren[1].fillColor = isDark ? BACKGROUND_TILE_DARK : BACKGROUND_TILE_LIGHT;
 
     const vectorChildren = backgroundGuideLayer.vectorBackground.children;
-    vectorChildren[0].fillColor = isDark ? WORKSPACE_BOUNDS_DARK : WORKSPACE_BOUNDS_LIGHT;
-    vectorChildren[1].children[0].fillColor = isDark ? BACKGROUND_DARK : BACKGROUND_LIGHT;
-    vectorChildren[1].children[1].fillColor = isDark ? BACKGROUND_TILE_DARK : BACKGROUND_TILE_LIGHT;
+    // In infinite canvas mode, workspace bounds might not exist
+    if (!isInfiniteCanvasEnabled() && vectorChildren.length > 1) {
+        vectorChildren[0].fillColor = isDark ? WORKSPACE_BOUNDS_DARK : WORKSPACE_BOUNDS_LIGHT;
+        vectorChildren[1].children[0].fillColor = isDark ? BACKGROUND_DARK : BACKGROUND_LIGHT;
+        vectorChildren[1].children[1].fillColor = isDark ? BACKGROUND_TILE_DARK : BACKGROUND_TILE_LIGHT;
+    } else if (isInfiniteCanvasEnabled() && vectorChildren.length > 0) {
+        // In infinite canvas mode, the background is the first (and possibly only) child
+        vectorChildren[0].children[0].fillColor = isDark ? BACKGROUND_DARK : BACKGROUND_LIGHT;
+        vectorChildren[0].children[1].fillColor = isDark ? BACKGROUND_TILE_DARK : BACKGROUND_TILE_LIGHT;
+    }
 
     const outlineLayer = getOutlineLayer();
     outlineLayer.children[0].strokeColor = isDark ? OUTLINE_INNER_DARK : OUTLINE_INNER_LIGHT;
@@ -376,6 +446,38 @@ const setupLayers = function (format) {
     paintLayer.activate();
 };
 
+/**
+ * Rebuild the background guide layer with correct sizing for current canvas mode
+ * @param {string} format - The current image format
+ * @return {object} The new background guide layer
+ */
+const rebuildBackgroundGuideLayer = function (format) {
+    const oldLayer = getBackgroundGuideLayer();
+    const layerIndex = oldLayer ? paper.project.layers.indexOf(oldLayer) : 0;
+    
+    // Remove old background layer
+    if (oldLayer) {
+        oldLayer.remove();
+    }
+    
+    // Create new background layer with current mode settings
+    const newLayer = _makeBackgroundGuideLayer(format);
+    
+    // Insert at the same position (should be at the back)
+    if (layerIndex >= 0) {
+        paper.project.insertLayer(layerIndex, newLayer);
+    }
+    newLayer.sendToBack();
+    
+    // Ensure painting layer is active
+    const paintingLayer = _getPaintingLayer();
+    if (paintingLayer) {
+        paintingLayer.activate();
+    }
+    
+    return newLayer;
+};
+
 export {
     CROSSHAIR_SIZE,
     CROSSHAIR_FULL_OPACITY,
@@ -390,5 +492,6 @@ export {
     getRaster,
     setGuideItem,
     updateTheme,
-    setupLayers
+    setupLayers,
+    rebuildBackgroundGuideLayer
 };

--- a/src/helper/selection-tools/move-tool.js
+++ b/src/helper/selection-tools/move-tool.js
@@ -5,7 +5,7 @@ import {getRootItem, isCompoundPathItem} from '../item';
 import {CROSSHAIR_FULL_OPACITY, getDragCrosshairLayer} from '../layer';
 import {checkPointsClose, snapDeltaToAngle} from '../math';
 import {clearSelection, cloneSelection, getSelectedLeafItems, getSelectedRootItems, setItemSelection} from '../selection';
-import {BASE, getActionBounds} from '../view';
+import {BASE, getActionBounds, isInfiniteCanvasEnabled} from '../view';
 
 /** Snap to align selection center to rotation center within this distance */
 const SNAPPING_THRESHOLD = 4;
@@ -124,8 +124,11 @@ class MoveTool {
         const point = event.point;
         const actionBounds = getActionBounds(this.mode in BitmapModes);
 
-        point.x = Math.max(actionBounds.left, Math.min(point.x, actionBounds.right));
-        point.y = Math.max(actionBounds.top, Math.min(point.y, actionBounds.bottom));
+        // In infinite canvas mode, do not clamp the point to action bounds
+        if (!isInfiniteCanvasEnabled()) {
+            point.x = Math.max(actionBounds.left, Math.min(point.x, actionBounds.right));
+            point.y = Math.max(actionBounds.top, Math.min(point.y, actionBounds.bottom));
+        }
 
         const dragVector = point.subtract(event.downPoint);
         let snapVector;

--- a/src/helper/selection-tools/nudge-tool.js
+++ b/src/helper/selection-tools/nudge-tool.js
@@ -1,6 +1,6 @@
 import paper from '@scratch/paper';
 import {getSelectedRootItems} from '../selection';
-import {getActionBounds} from '../view';
+import {getActionBounds, isInfiniteCanvasEnabled} from '../view';
 import {BitmapModes} from '../../lib/modes';
 
 const NUDGE_MORE_MULTIPLIER = 15;
@@ -42,20 +42,34 @@ class NudgeTool {
             }
         }
         const bounds = getActionBounds(this.boundingBoxTool.isBitmap);
-        const bottom = bounds.bottom - rect.top - 1;
-        const top = bounds.top - rect.bottom + 1;
-        const left = bounds.left - rect.right + 1;
-        const right = bounds.right - rect.left - 1;
-
         let translation;
-        if (event.key === 'up') {
-            translation = new paper.Point(0, Math.min(bottom, Math.max(-nudgeAmount, top)));
-        } else if (event.key === 'down') {
-            translation = new paper.Point(0, Math.max(top, Math.min(nudgeAmount, bottom)));
-        } else if (event.key === 'left') {
-            translation = new paper.Point(Math.min(right, Math.max(-nudgeAmount, left)), 0);
-        } else if (event.key === 'right') {
-            translation = new paper.Point(Math.max(left, Math.min(nudgeAmount, right)), 0);
+
+        if (isInfiniteCanvasEnabled()) {
+            // In infinite canvas mode, do not constrain nudge by bounds
+            if (event.key === 'up') {
+                translation = new paper.Point(0, -nudgeAmount);
+            } else if (event.key === 'down') {
+                translation = new paper.Point(0, nudgeAmount);
+            } else if (event.key === 'left') {
+                translation = new paper.Point(-nudgeAmount, 0);
+            } else if (event.key === 'right') {
+                translation = new paper.Point(nudgeAmount, 0);
+            }
+        } else {
+            const bottom = bounds.bottom - rect.top - 1;
+            const top = bounds.top - rect.bottom + 1;
+            const left = bounds.left - rect.right + 1;
+            const right = bounds.right - rect.left - 1;
+
+            if (event.key === 'up') {
+                translation = new paper.Point(0, Math.min(bottom, Math.max(-nudgeAmount, top)));
+            } else if (event.key === 'down') {
+                translation = new paper.Point(0, Math.max(top, Math.min(nudgeAmount, bottom)));
+            } else if (event.key === 'left') {
+                translation = new paper.Point(Math.min(right, Math.max(-nudgeAmount, left)), 0);
+            } else if (event.key === 'right') {
+                translation = new paper.Point(Math.max(left, Math.min(nudgeAmount, right)), 0);
+            }
         }
 
         if (translation) {

--- a/src/helper/selection-tools/point-tool.js
+++ b/src/helper/selection-tools/point-tool.js
@@ -1,5 +1,5 @@
 import {HANDLE_RATIO, snapDeltaToAngle} from '../math';
-import {getActionBounds} from '../view';
+import {getActionBounds, isInfiniteCanvasEnabled} from '../view';
 import {clearSelection, getSelectedLeafItems, getSelectedSegments} from '../selection';
 
 /** Subtool of ReshapeTool for moving control points. */
@@ -109,10 +109,12 @@ class PointTool {
         this.invertDeselect = false;
         this.deleteOnMouseUp = null;
 
-        const point = event.point;
+        let point = event.point;
         const bounds = getActionBounds();
-        point.x = Math.max(bounds.left, Math.min(point.x, bounds.right));
-        point.y = Math.max(bounds.top, Math.min(point.y, bounds.bottom));
+        if (!isInfiniteCanvasEnabled()) {
+            point.x = Math.max(bounds.left, Math.min(point.x, bounds.right));
+            point.y = Math.max(bounds.top, Math.min(point.y, bounds.bottom));
+        }
 
         if (!this.lastPoint) this.lastPoint = event.lastPoint;
         const dragVector = point.subtract(event.downPoint);

--- a/src/helper/selection-tools/scale-tool.js
+++ b/src/helper/selection-tools/scale-tool.js
@@ -1,6 +1,6 @@
 import paper from '@scratch/paper';
 import {getItems} from '../selection';
-import {getActionBounds} from '../view';
+import {getActionBounds, isInfiniteCanvasEnabled} from '../view';
 import {BitmapModes} from '../../lib/modes';
 
 const MIN_SCALE_FACTOR = 0.0001;
@@ -77,8 +77,12 @@ class ScaleTool {
         if (!this.active) return;
         const point = event.point;
         const bounds = getActionBounds(this.isBitmap);
-        point.x = Math.max(bounds.left, Math.min(point.x, bounds.right));
-        point.y = Math.max(bounds.top, Math.min(point.y, bounds.bottom));
+        
+        // In infinite canvas mode, do not clamp the point to bounds
+        if (!isInfiniteCanvasEnabled()) {
+            point.x = Math.max(bounds.left, Math.min(point.x, bounds.right));
+            point.y = Math.max(bounds.top, Math.min(point.y, bounds.bottom));
+        }
 
         if (!this.lastPoint) this.lastPoint = event.lastPoint;
         const delta = point.subtract(this.lastPoint);

--- a/src/helper/selection-tools/selection-box-tool.js
+++ b/src/helper/selection-tools/selection-box-tool.js
@@ -3,7 +3,7 @@ import {getHitBounds} from '../../helper/bitmap';
 import {rectSelect} from '../guides';
 import {getRaster} from '../layer';
 import {clearSelection, processRectangularSelection} from '../selection';
-import {BASE} from '../view';
+import {BASE, isInfiniteCanvasEnabled} from '../view';
 
 /** Tool to handle drag selection. A dotted line box appears and everything enclosed is selected. */
 class SelectionBoxTool {
@@ -46,14 +46,28 @@ class SelectionBoxTool {
     onMouseUpBitmap (event) {
         if (event.event.button > 0) return; // only first mouse button
         if (this.selectionRect) {
-            let rect = new paper.Rectangle({
-                from: new paper.Point(
-                    Math.max(0, Math.round(this.selectionRect.bounds.topLeft.x)),
-                    Math.max(0, Math.round(this.selectionRect.bounds.topLeft.y))),
-                to: new paper.Point(
-                    Math.min(BASE.ART_BOARD_WIDTH, Math.round(this.selectionRect.bounds.bottomRight.x)),
-                    Math.min(BASE.ART_BOARD_HEIGHT, Math.round(this.selectionRect.bounds.bottomRight.y)))
-            });
+            let rect;
+            if (isInfiniteCanvasEnabled()) {
+                // In infinite canvas mode, don't limit selection to art board bounds
+                const rasterBounds = getRaster().bounds;
+                rect = new paper.Rectangle({
+                    from: new paper.Point(
+                        Math.max(rasterBounds.left, Math.round(this.selectionRect.bounds.topLeft.x)),
+                        Math.max(rasterBounds.top, Math.round(this.selectionRect.bounds.topLeft.y))),
+                    to: new paper.Point(
+                        Math.min(rasterBounds.right, Math.round(this.selectionRect.bounds.bottomRight.x)),
+                        Math.min(rasterBounds.bottom, Math.round(this.selectionRect.bounds.bottomRight.y)))
+                });
+            } else {
+                rect = new paper.Rectangle({
+                    from: new paper.Point(
+                        Math.max(0, Math.round(this.selectionRect.bounds.topLeft.x)),
+                        Math.max(0, Math.round(this.selectionRect.bounds.topLeft.y))),
+                    to: new paper.Point(
+                        Math.min(BASE.ART_BOARD_WIDTH, Math.round(this.selectionRect.bounds.bottomRight.x)),
+                        Math.min(BASE.ART_BOARD_HEIGHT, Math.round(this.selectionRect.bounds.bottomRight.y)))
+                });
+            }
 
             // Trim/tighten selection bounds inwards to only the opaque region, excluding transparent pixels
             rect = getHitBounds(getRaster(), rect);

--- a/src/helper/view.js
+++ b/src/helper/view.js
@@ -5,6 +5,12 @@ import {getHitBounds} from './bitmap';
 import {CROSSHAIR_SIZE, getBackgroundGuideLayer, getDragCrosshairLayer, getRaster} from './layer';
 import {getAllRootItems, getSelectedRootItems} from './selection';
 
+// Check for infinite canvas mode via global variable
+// If window.scratchPaintInfiniteCanvas is true, enable infinite canvas mode
+// Otherwise, use the original bounded workspace behavior
+const isInfiniteCanvasEnabled = () => {
+    return typeof window !== 'undefined' && window.scratchPaintInfiniteCanvas === true;
+};
 
 const PADDING_PERCENT = 25; // Padding as a percent of the max of width/height of the sprite
 const BUFFER = 50; // Number of pixels of allowance around objects at the edges of the workspace
@@ -50,7 +56,29 @@ const getWorkspaceBounds = () => _workspaceBounds;
 */
 const setWorkspaceBounds = clipEmpty => {
     const items = getAllRootItems();
-    // Include the artboard and what's visible in the viewport
+    
+    if (isInfiniteCanvasEnabled()) {
+        // In infinite canvas mode, workspace bounds are dynamically calculated
+        // based on current view and content, without any fixed limits
+        let bounds = paper.view.bounds;
+        
+        // Include all drawn items with a reasonable buffer
+        for (const item of items) {
+            bounds = bounds.unite(item.bounds.expand(BUFFER));
+        }
+        
+        // Ensure minimum size includes the artboard
+        bounds = bounds.unite(BASE.ART_BOARD_BOUNDS);
+        
+        // Add extra padding for smooth navigation
+        const padding = Math.max(paper.view.bounds.width, paper.view.bounds.height) * 0.5;
+        bounds = bounds.expand(padding);
+        
+        _workspaceBounds = bounds;
+        return;
+    }
+    
+    // Original logic for bounded mode
     let bounds = BASE.ART_BOARD_BOUNDS;
     if (!clipEmpty) {
         bounds = bounds.unite(paper.view.bounds);
@@ -59,7 +87,7 @@ const setWorkspaceBounds = clipEmpty => {
     for (const item of items) {
         bounds = bounds.unite(item.bounds.expand(BUFFER));
     }
-    // Limit to max workspace bounds
+    // Limit to max workspace bounds in bounded mode
     bounds = bounds.intersect(BASE.MAX_WORKSPACE_BOUNDS.expand(BUFFER));
     let top = bounds.top;
     let left = bounds.left;
@@ -84,6 +112,12 @@ const setWorkspaceBounds = clipEmpty => {
 };
 
 const clampViewBounds = () => {
+    // Skip view bounds clamping if infinite canvas is enabled
+    if (isInfiniteCanvasEnabled()) {
+        setWorkspaceBounds();
+        return;
+    }
+    
     const {left, right, top, bottom} = paper.project.view.bounds;
     if (left < _workspaceBounds.left) {
         paper.project.view.scrollBy(new paper.Point(_workspaceBounds.left - left, 0));
@@ -170,6 +204,15 @@ const getActionBounds = isBitmap => {
     if (isBitmap) {
         return BASE.ART_BOARD_BOUNDS;
     }
+    
+    if (isInfiniteCanvasEnabled()) {
+        // In infinite canvas mode, allow actions across a much larger area
+        // that expands dynamically based on current view and workspace bounds
+        const currentWorkspace = getWorkspaceBounds();
+        const expandedBounds = currentWorkspace.expand(Math.max(currentWorkspace.width, currentWorkspace.height));
+        return expandedBounds;
+    }
+    
     return paper.view.bounds.unite(BASE.ART_BOARD_BOUNDS).intersect(BASE.MAX_WORKSPACE_BOUNDS);
 };
 
@@ -213,6 +256,7 @@ export {
     OUTERMOST_ZOOM_LEVEL,
     clampViewBounds,
     getActionBounds,
+    isInfiniteCanvasEnabled,
     pan,
     resetZoom,
     setWorkspaceBounds,

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -10,7 +10,7 @@ import {scaleWithStrokes} from '../helper/math';
 import {getSelectedLeafItems} from '../helper/selection';
 import {performSnapshot} from '../helper/undo';
 import {
-    BASE, setWorkspaceBounds
+    BASE, setWorkspaceBounds, isInfiniteCanvasEnabled
 } from '../helper/view';
 import Formats, {isBitmap, isVector} from '../lib/format';
 import Modes, {BitmapModes} from '../lib/modes';
@@ -152,8 +152,8 @@ const UpdateImageHOC = function (WrappedComponent) {
 
             showGuideLayers(guideLayers);
 
-            // Add back viewbox
-            if (workspaceMask) {
+            // Add back viewbox only in non-infinite canvas mode
+            if (workspaceMask && !isInfiniteCanvasEnabled()) {
                 paper.project.activeLayer.addChild(workspaceMask);
                 workspaceMask.clipMask = true;
             }

--- a/src/playground/playground.jsx
+++ b/src/playground/playground.jsx
@@ -47,7 +47,7 @@ class Playground extends React.Component {
             rotationCenterY: 400,
             imageFormat: 'svg', // 'svg', 'png', or 'jpg'
             image: svgString, // svg string or data URI
-            imageId: this.id, // If this changes, the paint editor will reload
+            imageId: String(this.id), // If this changes, the paint editor will reload
             rtl: rtl,
         };
         this.reusableCanvas = document.createElement('canvas');
@@ -159,12 +159,15 @@ class Playground extends React.Component {
             that.setState({
                 image: content,
                 name: file.name.split('.').slice(0, -1).join('.'),
-                imageId: ++that.id,
+                imageId: String(++that.id),
                 imageFormat: type,
                 rotationCenterX: undefined,
                 rotationCenterY: undefined,
             });
        }
+    }
+    infiniteCanvasModeToggle() {
+        if(window) window.scratchPaintInfiniteCanvas = !window.scratchPaintInfiniteCanvas;
     }
     render () {
         return (
@@ -177,6 +180,7 @@ class Playground extends React.Component {
                 <button className={styles.playgroundButton}  onClick={this.uploadImage}>Upload</button>
                 <input id={styles.fileInput} type="file" name="name" onChange={this.onUploadImage} />
                 <button className={styles.playgroundButton} onClick={this.downloadImage}>Download</button>
+                <button className={styles.playgroundButton} onClick={this.infiniteCanvasModeToggle}>Infinite Canvas</button>
             </div>
         );
     }


### PR DESCRIPTION
实现无限画布模式，修改包括：
1. 添加无限画布检测函数和全局开关(用于测试)
2. 调整视图边界计算逻辑
3. 修改工具类边界检查行为
4. 添加动态背景更新机制

在无限画布模式下：
- 移除工作区边界限制
- 支持自由平移和缩放
- 动态调整背景和画布大小
- 保持与原版行为的兼容性

### Resolves

_What Github issue does this resolve (please include link)?_

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_